### PR TITLE
fixed bug where if no issue was selected a hotspot was still created …

### DIFF
--- a/app/controllers/hotspots_controller.rb
+++ b/app/controllers/hotspots_controller.rb
@@ -36,21 +36,40 @@ class HotspotsController < ApplicationController
     @selected_issues = params[:issues] || {}
     @hotspot = Hotspot.new(hotspot_params)
     @all_issues = Hotspot.all_issues
-    if @hotspot.save and not(@selected_issues == {})
-        @selected_issues.each do |issue|
-          @hotspot.issues << Issue.where(issue_type: issue)
-        end
+
+    if @selected_issues == {}
+      flash.now[:warning] = "You have not selected an issue type."
+      render :new
+    elsif @hotspot.save
+      @selected_issues.each do |issue|
+        @hotspot.issues << Issue.where(issue_type: issue)
+      end
         
-        flash[:notice] = "You have successfully reported an issue. Thank you!"
-        redirect_to new_hotspot_path
+      flash[:notice] = "You have successfully reported an issue. Thank you!"
+      redirect_to new_hotspot_path
     else
-        if @hotspot.errors.any? 
+      if @hotspot.errors.any? 
           flash.now[:warning] = @hotspot.errors.full_messages.first 
-        else
-          flash.now[:warning] = "You have not filled out all required fields."
-        end
-        render :new
+      else
+        flash.now[:warning] = "You have not filled out all required fields."
+      end
+      render :new
     end
   end
   
 end
+    # if @hotspot.save and not(@selected_issues == {})
+    #     @selected_issues.each do |issue|
+    #       @hotspot.issues << Issue.where(issue_type: issue)
+    #     end
+        
+    #     flash[:notice] = "You have successfully reported an issue. Thank you!"
+    #     redirect_to new_hotspot_path
+    # else
+    #     if @hotspot.errors.any? 
+    #       flash.now[:warning] = @hotspot.errors.full_messages.first 
+    #     else
+    #       flash.now[:warning] = "You have not filled out all required fields."
+    #     end
+    #     render :new
+    # end


### PR DESCRIPTION
…but with no issue type
This may have caused the "empty" hotspot info markers because if no issue was selected the hotspot was still created without an issue type and would still show up on the map.